### PR TITLE
Hook prior to handler

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -20,7 +20,7 @@ const resolve = (tpl, context) => Mustache
   .render(tpl.replace(/\{/, '{{{').replace(/\}/, '}}}'), context);
 
 const register = (server) => {
-  server.ext('onPreResponse', (request, h) => {
+  server.ext('onCredentials', (request, h) => {
     const {
       payload, route, auth, params, query,
     } = request;

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -130,16 +130,13 @@ describe('hapi-field-auth / no options', async () => {
     expect(res.statusCode).to.be.equal(401);
   });
 
-  it('should issue error if protected route is not authenticated', async () => {
+  it('should not run if protected route is not authenticated', async () => {
     const res = await server.inject({
       method: 'PATCH',
       url: '/test/4711',
     });
     expect(res.statusCode).to.be.equal(401);
-    expect(listener.errors.calledOnce).to.be.equals(true);
-    const { tags, data } = listener.errors.getCall(0).args[1]; // event
-    expect(tags).to.be.deep.equal(['error']);
-    expect(data).to.be.equal('plugin hapi-field-auth: not authenticated');
+    expect(listener.errors.calledOnce).to.be.equals(false);
   });
 
   it('should allow fields if no special scope', async () => {
@@ -170,6 +167,7 @@ describe('hapi-field-auth / no options', async () => {
     });
     expect(res.statusCode).to.be.equal(403);
   });
+  
   it('should validate fields if field-level scope / validation fails for scope ', async () => {
     const res = await server.inject({
       method: 'PATCH',

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -138,7 +138,7 @@ describe('hapi-field-auth / no options', async () => {
       url: '/test/4711',
     });
     expect(res.statusCode).to.be.equal(401);
-    expect(listener.handlers.calledOnce).to.equal(false);
+    expect(listener.handlers.called).to.equal(false);
   });
 
   it('should not run if protected route is not authenticated', async () => {
@@ -147,8 +147,8 @@ describe('hapi-field-auth / no options', async () => {
       url: '/test/4711',
     });
     expect(res.statusCode).to.be.equal(401);
-    expect(listener.errors.calledOnce).to.be.equals(false);
-    expect(listener.handlers.calledOnce).to.equal(false);
+    expect(listener.errors.called).to.be.equals(false);
+    expect(listener.handlers.called).to.equal(false);
   });
 
   it('should allow fields if no special scope', async () => {
@@ -179,7 +179,7 @@ describe('hapi-field-auth / no options', async () => {
       },
     });
     expect(res.statusCode).to.be.equal(403);
-    expect(listener.handlers.calledOnce).to.equal(false);
+    expect(listener.handlers.called).to.equal(false);
   });
 
   it('should validate fields if field-level scope / validation fails for scope ', async () => {
@@ -195,7 +195,7 @@ describe('hapi-field-auth / no options', async () => {
       },
     });
     expect(res.statusCode).to.be.equal(400);
-    expect(listener.handlers.calledOnce).to.equal(false);
+    expect(listener.handlers.called).to.equal(false);
   });
 
   it('should protect fields if field-level scope / scope sufficient', async () => {
@@ -259,7 +259,7 @@ describe('hapi-field-auth / no options', async () => {
       },
     });
     expect(res.statusCode).to.be.equal(403);
-    expect(listener.handlers.calledOnce).to.equal(false);
+    expect(listener.handlers.called).to.equal(false);
   });
 
   it('should protect fields if field-level scope with params / scope sufficient', async () => {


### PR DESCRIPTION
PR for issue: https://github.com/frankthelen/hapi-field-auth/issues/11

Changes the plugin to be hooked on credentials rather than on preResponse. This makes the plugin prevent any handler from being run if it detects an error.

Commits:
* Hook the plugin prior to the handler running
* Fixed authentication test
* Added checks to see the handler is called in appropriate situations